### PR TITLE
AlaiaNakama-feature-case00258806-cambrium-access-point

### DIFF
--- a/entity-types/ext-access_point/cambrium-access-point-dashboard.json
+++ b/entity-types/ext-access_point/cambrium-access-point-dashboard.json
@@ -1,0 +1,101 @@
+{
+    "name": "Cambrium Access Point",
+    "description": null,
+    "pages": [
+      {
+        "name": "Cambrium Access Point",
+        "description": null,
+        "widgets": [
+          {
+            "title": "Summary",
+            "layout": {
+              "column": 1,
+              "row": 1,
+              "width": 2,
+              "height": 6
+            },
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "rawConfiguration": {
+              "dataFormatters": [
+                {
+                  "name": "Last Update",
+                  "type": "date"
+                },
+                {
+                  "name": "Uptime (Days)",
+                  "precision": 2,
+                  "type": "decimal"
+                }
+              ],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT\n  latest(src_addr) AS 'Polling IP',\n  latest(SysObjectID) AS 'SysObjectID',\n  latest(entity.type) AS 'NR Entity Type',\n  latest(instrumentation.name) AS 'Ktranslate Profile',\n  latest(tags.container_service) AS 'Ktranslate Instance',\n  latest(kentik.snmp.Uptime)/8640000 AS 'Uptime (Days)',\n  latest(timestamp) AS 'Last Update',\n  latest(PollingHealth) AS 'Current Polling Health',\n  if(latest(PollingHealth) = 'GOOD', '', latest(PollingHealthReason)) AS 'Health Reason'"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "AP Details",
+            "layout": {
+              "column": 10,
+              "row": 5,
+              "width": 4,
+              "height": 4
+            },
+            "visualization": {
+              "id": "viz.table"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM (\n  FROM Metric \n  SELECT latest(kentik.snmp.mcs) AS 'mcs', latest(kentik.snmp.snr) AS 'snr', latest(kentik.snmp.rssi) AS 'rssi'\n  WHERE instrumentation.provider = 'kentik'\n    AND provider = 'kentik-cambium-ap'\n    AND `mib-name`  = 'TERRAGRAPH-RADIO-MIB'\n  FACET device_name, tags.kentik.model, src_addr, concat(device_name, '_', Index) AS device_name_and_if_index, Index\n  LIMIT MAX\n  )\nINNER JOIN (\n  FROM Metric \n  SELECT filter(latest(`tgRadioInterfacesTable`), WHERE Index LIKE '1.2.%') AS 'if_Name'\n    , filter(latest(`tgRadioInterfacesTable`), WHERE Index LIKE '1.3.%') AS 'MAC_Addr'\n    , filter(latest(`tgRadioInterfacesTable`), WHERE Index LIKE '1.4.%') AS 'remote_MAC_Addr'\n  WHERE metricName = 'kentik.snmp.tgRadioInterfacesTable'\n    AND provider = 'kentik-cambium-ap'\n    AND `mib-name`  = 'TERRAGRAPH-RADIO-MIB'\n  FACET concat(device_name, '_', aparse(Index, '%.%.*')) AS device_name_and_if_index\n  LIMIT MAX\n  ) ON device_name_and_if_index\nSELECT latest(mcs), latest(snr), latest(rssi)\nFACET device_name, tags.kentik.model, src_addr, Index AS 'if_Index', if_Name, MAC_Addr, remote_MAC_Addr\nLIMIT MAX"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          },
+          {
+            "title": "Interface Status",
+            "layout": {
+              "column": 5,
+              "row": 3,
+              "width": 7,
+              "height": 4
+            },
+            "visualization": {
+              "id": "viz.table"
+            },
+            "rawConfiguration": {
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "FROM Metric SELECT\n  latest(if_OperStatus) AS 'Operational Status'\nFACET\n  if_Description AS 'Interface'\nWHERE if_AdminStatus = 'up'\nLIMIT MAX"
+                }
+              ],
+              "platformOptions": {
+                "ignoreTimeRange": false
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }

--- a/entity-types/ext-access_point/definition.yml
+++ b/entity-types/ext-access_point/definition.yml
@@ -39,6 +39,24 @@ synthesis:
     prefixedTags:
       tags.:
         ttl: PT4H
+  # kentik - cambrium
+  - identifier: device_name
+    name: device_name
+    encodeIdentifierInGUID: true
+    conditions:
+    - attribute: provider
+      value: kentik-cambium-ap
+    tags:
+      src_addr:
+        entityTagName: device_ip
+        multiValue: false
+      tags.container_service:
+        entityTagName: container_service
+        multiValue: false
+    # Add a 4 hour ttl on all tags ingested in metric api using tags. prefix
+    prefixedTags:
+      tags.:
+        ttl: PT4H
   # kentik - others
   - identifier: device_name
     name: device_name
@@ -90,3 +108,5 @@ dashboardTemplates:
     template: cisco-access-point-dashboard.json
   kentik/fortinet-fortiap:
     template: fortinet-access-point-dashboard.json
+  kentik/cambrium-mib:
+    template: cambrium-access-point-dashboard.json


### PR DESCRIPTION
Updating ext-access_point definition and adding dashboard for Cambrium AP. Per request in case 00258806, so that Cambrium AP devices detected with new Kentik snmp profile (link below) are synthesized correctly as ACCESS_POINT entity types. Also so that the metrics added in the tgRadioInterfacesTable are reported in the default entity view for the Cambrium AP entities: https://github.com/kentik/snmp-profiles/blob/main/profiles/kentik_snmp/Cambium/cambium-mib.yml

### Relevant information

<!--
  Describe what you have done.
  Provide details that are relevant to the PR

  Always think that the person reviewing the PR doesn't have the context you have.

  Links to examples, documentation and similar resources make the process easier to review.
-->

<!--
  Contributions to this repository are reviewed at least twice a week

  There's no further action required once the PR has been created.
 -->

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid. 
* [x] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
